### PR TITLE
Node upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [17, 18]
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/test/adapter/pokerstars.js
+++ b/test/adapter/pokerstars.js
@@ -2,12 +2,13 @@ const sinon = require('sinon');
 const assert = require('assert');
 
 const fs = require('fs').promises;
+const origReadFile = fs.readFile;
 
 const Fixture = require('../../src/adapter/pokerstars');
 
 describe('PokerStars adapter', () => {
     it('should parse the CSV', async () => {
-        sinon.stub(fs, 'readFile').resolves([
+        sinon.stub(fs, 'readFile').callsFake(origReadFile).withArgs('fixsource').resolves([
             ["Playing History Audit 'username' from 2020/01/04 12:00 AM to 2022/02/19 11:59 PM"],
             ['Transaction Details', 'Individual Transaction Amounts', 'Running Balance'],
             [
@@ -42,7 +43,7 @@ describe('PokerStars adapter', () => {
         ].map(r => r.join(',')).join('\r\n'));
 
         const fixture = new Fixture('', {
-            source: '',
+            source: 'fixsource',
             name: 'PokerStars'
         }, {
             silly: () => {},


### PR DESCRIPTION
For Node 19+, the `import()` function calls `fs.readFile` behind the scenes. This means that stubbing the function in tests was causing the import to fail.

The fix in the test causes the stub to use the original behaviour for normal calls, but only perform the stub behaviour on specific arguments (when the fixture loads the config file).